### PR TITLE
Add SD Card support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository is structured to allow modification of the configuration files u
 |   ├── pm25.yaml           # PM2.5 sensor
 |   ├── rtc.yaml            # clocks
 |   ├── sample.yaml         # sampling loop
+|   ├── sd.yaml             # SD card
 |   ├── spl.yaml            # sound pressure level sensor
 |   ├── substitutions.yaml  # substitutions
 |   ├── tair.yaml           # air temperature and RH sensor
@@ -33,7 +34,7 @@ This repository is structured to allow modification of the configuration files u
 |   └── ...
 ```
 
-The configuration of these components has been setup for the reliable operation of SAMBA as per the requirements of the IEQ Lab. However, it is possible for someone to modify the way SAMBA works by editing these files. An example configuration for the temperature and humidity sensor is as follows:
+The configuration of these components has been set-up for the reliable operation of SAMBA as per the requirements of the IEQ Lab. However, it is possible for someone to modify the way SAMBA works by editing these files. An example configuration for the temperature and humidity sensor is as follows:
 
 ```
 sensor:
@@ -48,10 +49,10 @@ This is a basic configuration that will return temperature and relative humidity
 
 The `components/` subdirectory is where ESPHome expects to find [external components](https://esphome.io/components/external_components.html) that provide additional functionality beyond what is offered natively in ESPHome. We are using four external components in SAMBA: 
 
-1.  `i2s` to sample audio with the microphone.
-2.  `sound_level_meter` for calculating SPL (eq, dBA, dBC).
-3.  `senseair_i2c` to communicate with [K30 CO2 sensor](https://www.co2meter.com/en-au/products/k-30-co2-sensor-module). 
-4.  `influxdb_writer` for uploading samples to an InfluxDB bucket.
+1.  `sound_level_meter` for calculating SPL (eq, dBA, dBC etc.).
+2.  `senseair_i2c` to communicate with [K30 CO2 sensor](https://www.co2meter.com/en-au/products/k-30-co2-sensor-module). 
+3.  `influxdb` for uploading samples to an InfluxDB bucket.
+4.  `sd_spi_card` for writing measurements to an SD card
 
 The hope is to have these external components merged into esphome at some point so the broader community can use them.
 
@@ -75,9 +76,9 @@ SAMBA is equipped with sensors that are configured using .yaml files in `config/
 A key part of the SAMBA configuration is the sampling routine. SAMBA is configured to constantly measure environmental parameters, periodically summarise those measurements using the median with a moving window, and then upload them at a set interval. The sampling routine is as follows:
 
 1.  Each sensor is set to measure at a given frequency. This ranges from 500ms (for SPL) to 60s for VOC/NOx Index; see table below for summary.
-2.  Simple quality assurance is done on the measurements. Sensors have a [filter](https://esphome.io/components/sensor/index.html#clamp) to remove obvious outliers e.g. temperatures below -10°C and above 60°C. Some have sensors have a linear calibration (implemented as a [lambda function](https://esphome.io/cookbook/lambda_magic.html)) e.g. converting voltage to airspeed. All sensors use a [simple moving median](https://esphome.io/components/sensor/index.html#median) that updates the sensor value every 30s.
+2.  Simple quality assurance is done on the measurements. Sensors have a [filter](https://esphome.io/components/sensor/index.html#clamp) to remove obvious outliers (e.g. temperatures below -10°C and above 60°C) or NaN readings. Some have sensors have a linear calibration (implemented as a [lambda function](https://esphome.io/cookbook/lambda_magic.html)) e.g. converting voltage to airspeed. All sensors use a [simple moving median](https://esphome.io/components/sensor/index.html#median).
 3.  The sample loop is triggered every 5-minutes using a [cron task on the RTC](https://esphome.io/components/time/index.html). The loop is a [script component](https://esphome.io/guides/automations.html#script-component) that executes a set of steps; details are given in [sample.yaml](https://github.com/IEQLab/samba/blob/main/config/sample.yaml) in `config/`. 
-4. The script first updates the [template sensors](https://esphome.io/components/sensor/template.html) to retrieve the latest measurement from the sensor (after the filters and moving median), and then publishes those data to Home Assistant or InfluxDB. The LED will flash with each upload.
+4.  The script first updates the [template sensors](https://esphome.io/components/sensor/template.html) to retrieve the latest measurement from the sensor (after the filters and moving median), and then publishes those data to Home Assistant, InfluxDB and/or an SD card. The LED will turn on for 2s with each upload.
 
 The following table summarises the sampling and filters (ordered sequentially) used in the default SAMBA configuration. Again, users are free to modify this but no support will be offered by the IEQ Lab.
 
@@ -86,8 +87,8 @@ The following table summarises the sampling and filters (ordered sequentially) u
 | Air Temperature | 30s | clamp; moving median; linear calibration |
 | Relative Humidity | 30s | clamp; moving median; linear calibration |
 | Globe Temperature | 30s | clamp; moving median; linear calibration |
-| Air Speed | 1s | clamp; moving median; multivariate calibration; clamp |
-| CO2 | 30s | filter; clamp; moving median; linear calibration; clamp |
+| Air Speed | 2s | clamp; moving median; multivariate calibration; clamp |
+| CO2 | 15s | filter; clamp; moving median; linear calibration; clamp |
 | PM2.5 | 1s | clamp; moving median |
 | VOC Index | 30s | moving median |
 | NOx Index | 30s | moving median |
@@ -96,19 +97,17 @@ The following table summarises the sampling and filters (ordered sequentially) u
 
 ### 📈 Data
 
-The published measurements from SAMBA get sent every 5-minutes to a Home Assistant instance and/or an InfluxDB bucket. 
+The published measurements from SAMBA get sent every 5-minutes to a Home Assistant instance, an InfluxDB bucket, and/or an SD card.
 
 [Home Assistant](https://www.home-assistant.io) is an open-source home automation platform that integrates thousands of consumer devices in a no-code environment. The advantage of Home Assistant is it is easy to use (especially for non-technical types). The disadvantage is that it requires another piece of hardware (e.g. Raspberry Pi) and it requires some tinkering to store raw data longer than 10 days. It is most beneficial if the research project involves other kinds of measurements e.g. energy monitoring or window/door openings. Communication between the SAMBA and Home Assistant is done using the native [API Component](https://esphome.io/components/api.html) in ESPHome.
 
-[InfluxDB](https://www.influxdata.com/products/influxdb-overview/) is an open-source time series database. It has high-speed read and write that is optimised for real-time data in IoT applications. It can be deployed on most server environments for free, and [InfluxData](https://www.influxdata.com) offer a hosted service that has a free and paid tiers (based on usage). The advantage is that it removes additional hardware layers. The disadvantage is that it requires the SAMBA device to have an active internet connection. It is most beneficial when the research project is deploying SAMBAs only e.g. a field study in office buildings. Communication between the SAMBA and InfluxDB is done using the external component in `components/influxdb_writer`.
-
-If you want to modify the InfluxDB configuration then we recommend familiarising yourself with [key concepts of InfluxDB](https://docs.influxdata.com/influxdb/v1/concepts/key_concepts/) first, like measurement, tags, and fields. No support is given for InfluxDB buckets other than those maintained by the IEQ Lab.
+[InfluxDB](https://www.influxdata.com/products/influxdb-overview/) is an open-source time series database. It has high-speed read and write that is optimised for real-time data in IoT applications. It can be deployed on most server environments for free, and [InfluxData](https://www.influxdata.com) offer a hosted service that has a free and paid tiers (based on usage). The advantage is that it removes additional hardware layers. The disadvantage is that it requires the SAMBA device to have an active internet connection. It is most beneficial when the research project is deploying SAMBAs only e.g. a field study in office buildings. Communication between the SAMBA and InfluxDB is done using the external component in `components/influxdb`. By default, the InfluxDB tags used for all measurement uploads are the building, level, and zone IDs that are set as [global variables](https://github.com/IEQLab/samba/tree/main/config/globals.yaml) on the SAMBA device. If you want to modify the InfluxDB configuration, we recommend familiarising yourself with [key concepts of InfluxDB](https://docs.influxdata.com/influxdb/v1/concepts/key_concepts/) first, like measurement, tags, and fields. No support is given for InfluxDB buckets other than those maintained by the IEQ Lab.
 
 ### 🚀️ User Guide ###
 
-The following section details how every SAMBA device is configured by the IEQ Lab. To begin, make sure the [ESPHome Command Line Interface](https://esphome.io/guides/cli.html) is installed. Instructions can be found on the [ESPHome website](https://esphome.io/guides/installing_esphome).
+The following section details how every SAMBA device is configured by the IEQ Lab. To begin, make sure the [ESPHome Command Line Interface](https://esphome.io/guides/cli.html) is installed. Instructions can be found on the [ESPHome website](https://esphome.io/guides/installing_esphome). The minimum version of ESPHome is currently 2025.10.0. 
 
-SAMBAs are initially flashed with [`setup.yaml`](https://github.com/IEQLab/samba/blob/main/setup.yaml) in the root directory, a basic configuration that loads device-specific parameters (e.g. calibration coefficients), creates a wireless hotspot to configure WiFi networks, and then downloads the latest SAMBA firmware from Github. The latest SAMBA firmware is compiled from [`samba.yaml`](https://github.com/IEQLab/samba/blob/main/samba.yaml) in the root directory, which will source all the relevant configuration in `config/`.
+SAMBAs are initially flashed with [`samba_setup.yaml`](https://github.com/IEQLab/samba/blob/main/samba_setup.yaml) in the root directory. This is a basic configuration that loads device-specific parameters (e.g. calibration coefficients), creates a wireless hotspot to configure WiFi networks, and then starts a web server that allows users to configure the device. Once done, the user can initiate the download of the [latest production firmware from Github](https://github.com/IEQLab/samba/tree/main/firmware) that has been compiled from [`samba.yaml`](https://github.com/IEQLab/samba/blob/main/samba.yaml) in the root directory.
 
 #### 🌱 Initial Setup ####
 
@@ -117,31 +116,31 @@ Access to the ESP32 is through the USB-C port on SAMBAs main PCB. There is a sin
 0. [Optional] Erase the ESP32 flash memory from earlier deployments: `esptool.py --chip esp32 erase_flash`.
 1.  Clone the [SAMBA Github Repository](https://github.com/IEQLab/samba/tree/main) to your local device and open that directory.
 2.  Open a terminal window and `cd` to the working folder where the SAMBA Github repo was cloned.
-3.  The initial setup script is `samba_setup.yaml`. It contains placeholder calibration coefficients - these can be changed later.
+3.  The initial set-up script is `samba_setup.yaml`. It contains placeholder calibration coefficients - these can be changed later.
 4.  Enter the following command to compile and upload the binary file to the SAMBA: `esphome run samba_setup.yaml`. Note that you will need to select the serial device before uploading; alternatively, specify the serial connection e.g. `esphome run setup.yaml --device /dev/cu.usbserial-10`.
 
-It should take about 30 seconds to flash the firmware. The Led should flash green and blue to indicate it is on but not connected to WiFi. If the SAMBA is being relocated, disconnect the USB-C cable once it is finished flashing, unplug the power, put the housing back on, and tighten the hex bolt. Place the SAMBA in its new location, power it on, and follow the below steps to configure the WiFi:
+It should take about 30 seconds to flash the firmware. The LED should flash green and blue to indicate it is on but not connected to WiFi. If the SAMBA is being relocated, disconnect the USB-C cable once it is finished flashing, unplug the power, put the housing back on, and tighten the hex bolt. Place the SAMBA in its new location, power it on, and follow the below steps to configure the WiFi:
 
-1.  Use another device (e.g. smartphone, laptp) to join the `samba_connect` ad-hoc WiFi and open the [captive portal](https://esphome.io/components/captive_portal.html) by entering [http://192.168.4.1/](http://192.168.4.1/) into your browser.
-2.  Select the 2.4GHz network to join from the list and enter in the password.
-3.  The SAMBA will connect to the network and then launch a web server to display the configuration settings and terminal window. This can be accessed through a browser at the IP address of the SAMBA e.g. `192.168.1.50`. 
-4.  Enter the location (building name, level/room number, and zone name) and the calibration coefficients. CO2, illuminance, air temperature, relative humidity, and globe temperature are linear calibrations (e.g. y = mx + b); the two air speed sensors are power regressions (e.g. y = a * x^b).
-3.  Once the configuration is complete, click the 'Deploy SAMBA' button to attempt to download and flash the latest firmware stored in [`firmware/`](https://github.com/IEQLab/samba/tree/main/firmware) on the IEQ Lab Github. Once that is done, the SAMBA will reboot and start sampling automatically. The status LED should blink slower to indicate it is warming up; this will stop once it enters the sampling routine.
+1.  Use another device (e.g. smartphone, laptop) to join the `samba_connect` ad-hoc WiFi and open the [captive portal](https://esphome.io/components/captive_portal.html) by navigating to [http://192.168.4.1/](http://192.168.4.1/) into your browser.
+2.  Select the available 2.4GHz network to join from the list and enter the password.
+3.  SAMBA will connect to the network and then launch a web server to display the configuration settings and terminal window. This can be accessed through a browser at the IP address of the SAMBA on the local network e.g. `192.168.1.XXX`. 
+4.  Enter the location tags (building name, level/room number, and zone name) and the calibration coefficients. CO2, illuminance, air temperature, relative humidity, and globe temperature are linear calibrations (e.g. y = mx + b); the two air speed sensors are power regressions (e.g. y = a * x^b).
+3.  Once the configuration is complete, click the 'Deploy SAMBA' button to attempt to download and flash the latest firmware stored in [`firmware/`](https://github.com/IEQLab/samba/tree/main/firmware) on the IEQ Lab Github. Once that is done, the SAMBA will reboot and start sampling automatically. The status LED should blink green to indicate it is warming up; this will stop once it enters the sampling routine.
 
 #### 🎯 Compiling Base Firmware [IEQ Lab] ####
 
-The IEQ Lab will actively maintain the SAMBA firmware and publish updates to the [Github repository](https://github.com/IEQLab/samba/tree/main). This might involve performance improvements or additional features. In this case, the IEQ Lab will push new binaries to `firmware/` which can then be flashed remotely using [OTA updates](https://esphome.io/components/ota/http_request.html). For Lab staff wishing to update the firmware, follow these steps:
+The IEQ Lab will actively maintain the SAMBA firmware and publish updates to the [Github repository](https://github.com/IEQLab/samba/tree/main). This might involve performance improvements or additional features. In this case, the IEQ Lab will push new binaries to `firmware/` which will be flashed remotely using [OTA updates](https://esphome.io/components/ota/http_request.html). For Lab staff wishing to update the firmware, follow these steps:
 
 1.  [Required] Speak to Tom before doing anything 🤠
-2.  Make the agreed modifications to the relevant .yaml files in `config/...` and test EXTENSIVELY.
+2.  Make the agreed modifications to the relevant .yaml files in `config/` and test EXTENSIVELY.
 3.  Bump the project version in [`esp32.yaml`](https://github.com/IEQLab/samba/blob/ebebc4b091f836f893ec4236af8086405198ec6a/config/esp32.yaml#L16)
 4.  Once the new firmware is confirmed stable, generate the compiled bin: `esphome compile samba.yaml`
 5.  Move the compiled ota firmware to the firmware directory: `cp .esphome/build/samba/.pioenvs/samba/firmware.ota.bin firmware/samba_v2.XX.XX.bin`
 6.  Generate a new md5 hash and print it to terminal: `md5 firmware/samba_v2.XX.XX.bin`
-7.  Update the [`manifest.json`](https://github.com/IEQLab/samba/blob/main/manifest.json) file to include the new bin path and md5 hash.
+7.  Update the [`manifest.json`](https://github.com/IEQLab/samba/blob/main/manifest.json) file and the [`samba_setup.yaml`](https://github.com/IEQLab/samba/blob/main/samba_setup.yaml) to include the new bin path and md5 hash.
 7.  Push the new .bin and updated manifest.json to the SAMBA Github repository.
 
-Currently, SAMBAs only check for new firmware during their initial setup. Future firmware will implement routine updates e.g. check once per week. As such, it's extremely important that firmware are extensively tested otherwise they could (worst case scenario) brick the entire SAMBA fleet.
+SAMBAs will check for updates once per week (4 am on Mondays) and automatically flash anew update if available. As such, it's extremely important that firmware are extensively tested BEFORE being pushed to Github otherwise they could (worst case scenario) brick the entire SAMBA fleet.
 
 #### 🆕 Modifying Firmware ####
 
@@ -155,3 +154,7 @@ Users are free to modify the SAMBA firmware to suit their needs. However, we str
 4.  Compile and upload the firmware to SAMBA via USB-C with `esphome run samba.yaml` or wirelessly (if in the same WLAN) with the SAMBA IP address `esphome run samba.yaml --device 192.168.1.XXX`.
 
 The user is responsible for managing the device if the firmware is modified.
+
+### 🛠️ Project Maintenance
+
+This is an active project to build an open research platform to help advance healthy, high-performance buildings. If you're interested in using SAMBA in your project or contributing to it's development, let's chat 😊 You can start a [Github discussion thread](https://github.com/IEQLab/samba/discussions) or email Tom.

--- a/components/sd_spi_card/__init__.py
+++ b/components/sd_spi_card/__init__.py
@@ -1,0 +1,148 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins, automation
+from esphome.const import CONF_ID, CONF_TRIGGER_ID
+
+CODEOWNERS = ["@yourname"]
+DEPENDENCIES = []
+
+CONF_ON_MOUNT = "on_mount"
+
+sd_ns = cg.esphome_ns.namespace("sd_spi_card")
+SdSpiCard = sd_ns.class_("SdSpiCard", cg.Component)
+
+# Triggers
+SdSpiCardMountTrigger = sd_ns.class_("SdSpiCardMountTrigger", automation.Trigger.template())
+
+# Actions
+AppendFileAction = sd_ns.class_("AppendFileAction", automation.Action)
+WriteFileAction = sd_ns.class_("WriteFileAction", automation.Action)
+SyncAction = sd_ns.class_("SyncAction", automation.Action)
+CreateFileAction = sd_ns.class_("CreateFileAction", automation.Action)
+
+# Define config keys
+CONF_PATH = "path"
+CONF_CONTENT = "content"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(SdSpiCard),
+        cv.Required("clk_pin"): pins.internal_gpio_output_pin_number,
+        cv.Required("mosi_pin"): pins.internal_gpio_output_pin_number,
+        cv.Required("miso_pin"): pins.internal_gpio_input_pin_number,
+        cv.Required("cs_pin"): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_ON_MOUNT): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SdSpiCardMountTrigger),
+            }
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    cg.add(var.set_pins(
+        config["clk_pin"],
+        config["mosi_pin"],
+        config["miso_pin"],
+        config["cs_pin"]
+    ))
+    
+    # Register on_mount trigger
+    for conf in config.get(CONF_ON_MOUNT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+
+
+# Append file action
+@automation.register_action(
+    "sd_spi_card.append_file",
+    AppendFileAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(SdSpiCard),
+            cv.Required(CONF_PATH): cv.templatable(cv.string),
+            cv.Required(CONF_CONTENT): cv.templatable(cv.string),
+        }
+    ),
+)
+async def append_file_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    
+    template_ = await cg.templatable(config[CONF_PATH], args, cg.std_string)
+    cg.add(var.set_path(template_))
+    
+    template_ = await cg.templatable(config[CONF_CONTENT], args, cg.std_string)
+    cg.add(var.set_content(template_))
+    
+    return var
+
+
+# Write file action
+@automation.register_action(
+    "sd_spi_card.write_file",
+    WriteFileAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(SdSpiCard),
+            cv.Required(CONF_PATH): cv.templatable(cv.string),
+            cv.Required(CONF_CONTENT): cv.templatable(cv.string),
+        }
+    ),
+)
+async def write_file_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    
+    template_ = await cg.templatable(config[CONF_PATH], args, cg.std_string)
+    cg.add(var.set_path(template_))
+    
+    template_ = await cg.templatable(config[CONF_CONTENT], args, cg.std_string)
+    cg.add(var.set_content(template_))
+    
+    return var
+
+
+# Sync action
+@automation.register_action(
+    "sd_spi_card.sync",
+    SyncAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(SdSpiCard),
+        }
+    ),
+)
+async def sync_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    return var
+
+
+# Create file action
+@automation.register_action(
+    "sd_spi_card.create_file",
+    CreateFileAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(SdSpiCard),
+            cv.Required(CONF_PATH): cv.templatable(cv.string),
+            cv.Optional(CONF_CONTENT, default=""): cv.templatable(cv.string),
+        }
+    ),
+)
+async def create_file_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    
+    template_ = await cg.templatable(config[CONF_PATH], args, cg.std_string)
+    cg.add(var.set_path(template_))
+    
+    template_ = await cg.templatable(config[CONF_CONTENT], args, cg.std_string)
+    cg.add(var.set_content(template_))
+    
+    return var

--- a/components/sd_spi_card/__init__.py
+++ b/components/sd_spi_card/__init__.py
@@ -3,10 +3,11 @@ import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
-CODEOWNERS = ["@yourname"]
+CODEOWNERS = ["@IEQLab"]
 DEPENDENCIES = []
 
 CONF_ON_MOUNT = "on_mount"
+CONF_AUTO_MOUNT = "auto_mount"
 
 sd_ns = cg.esphome_ns.namespace("sd_spi_card")
 SdSpiCard = sd_ns.class_("SdSpiCard", cg.Component)
@@ -19,6 +20,7 @@ AppendFileAction = sd_ns.class_("AppendFileAction", automation.Action)
 WriteFileAction = sd_ns.class_("WriteFileAction", automation.Action)
 SyncAction = sd_ns.class_("SyncAction", automation.Action)
 CreateFileAction = sd_ns.class_("CreateFileAction", automation.Action)
+MountAction = sd_ns.class_("MountAction", automation.Action)
 
 # Define config keys
 CONF_PATH = "path"
@@ -31,6 +33,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required("mosi_pin"): pins.internal_gpio_output_pin_number,
         cv.Required("miso_pin"): pins.internal_gpio_input_pin_number,
         cv.Required("cs_pin"): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_AUTO_MOUNT, default=True): cv.boolean,
         cv.Optional(CONF_ON_MOUNT): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SdSpiCardMountTrigger),
@@ -50,6 +53,8 @@ async def to_code(config):
         config["miso_pin"],
         config["cs_pin"]
     ))
+    
+    cg.add(var.set_auto_mount(config[CONF_AUTO_MOUNT]))
     
     # Register on_mount trigger
     for conf in config.get(CONF_ON_MOUNT, []):
@@ -145,4 +150,20 @@ async def create_file_action_to_code(config, action_id, template_arg, args):
     template_ = await cg.templatable(config[CONF_CONTENT], args, cg.std_string)
     cg.add(var.set_content(template_))
     
+    return var
+
+
+# Mount action
+@automation.register_action(
+    "sd_spi_card.mount",
+    MountAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(SdSpiCard),
+        }
+    ),
+)
+async def mount_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
     return var

--- a/components/sd_spi_card/automation.h
+++ b/components/sd_spi_card/automation.h
@@ -8,7 +8,7 @@ namespace sd_spi_card {
 
 // Trigger that fires when SD card is mounted
 class SdSpiCardMountTrigger : public Trigger<> {
- public:
+public:
   explicit SdSpiCardMountTrigger(SdSpiCard *parent) {
     parent->add_on_mount_callback([this]() { this->trigger(); });
   }
@@ -16,101 +16,116 @@ class SdSpiCardMountTrigger : public Trigger<> {
 
 template<typename... Ts>
 class AppendFileAction : public Action<Ts...> {
- public:
+public:
   explicit AppendFileAction(SdSpiCard *parent) : parent_(parent) {}
-
+  
   TEMPLATABLE_VALUE(std::string, path)
-  TEMPLATABLE_VALUE(std::string, content)
-
-  void play(Ts... x) override {
-    auto path_str = this->path_.value(x...);
-    auto content_str = this->content_.value(x...);
+    TEMPLATABLE_VALUE(std::string, content)
     
-    if (path_str.empty()) {
-      ESP_LOGW("sd_spi_card.action", "Path is empty, skipping write");
-      return;
+    void play(Ts... x) override {
+      auto path_str = this->path_.value(x...);
+      auto content_str = this->content_.value(x...);
+      
+      if (path_str.empty()) {
+        ESP_LOGW("sd_spi_card.action", "Path is empty, skipping write");
+        return;
+      }
+      
+      std::vector<uint8_t> data(content_str.begin(), content_str.end());
+      auto result = this->parent_->append_file(path_str, data);
+      
+      if (result != WriteResult::SUCCESS) {
+        ESP_LOGW("sd_spi_card.action", "Failed to append to file: %s", path_str.c_str());
+      }
     }
-    
-    std::vector<uint8_t> data(content_str.begin(), content_str.end());
-    auto result = this->parent_->append_file(path_str, data);
-    
-    if (result != WriteResult::SUCCESS) {
-      ESP_LOGW("sd_spi_card.action", "Failed to append to file: %s", path_str.c_str());
-    }
-  }
-
- protected:
+  
+protected:
   SdSpiCard *parent_;
 };
 
 template<typename... Ts>
 class WriteFileAction : public Action<Ts...> {
- public:
+public:
   explicit WriteFileAction(SdSpiCard *parent) : parent_(parent) {}
-
+  
   TEMPLATABLE_VALUE(std::string, path)
-  TEMPLATABLE_VALUE(std::string, content)
-
-  void play(Ts... x) override {
-    auto path_str = this->path_.value(x...);
-    auto content_str = this->content_.value(x...);
+    TEMPLATABLE_VALUE(std::string, content)
     
-    if (path_str.empty()) {
-      ESP_LOGW("sd_spi_card.action", "Path is empty, skipping write");
-      return;
+    void play(Ts... x) override {
+      auto path_str = this->path_.value(x...);
+      auto content_str = this->content_.value(x...);
+      
+      if (path_str.empty()) {
+        ESP_LOGW("sd_spi_card.action", "Path is empty, skipping write");
+        return;
+      }
+      
+      std::vector<uint8_t> data(content_str.begin(), content_str.end());
+      auto result = this->parent_->write_file(path_str, data);
+      
+      if (result != WriteResult::SUCCESS) {
+        ESP_LOGW("sd_spi_card.action", "Failed to write file: %s", path_str.c_str());
+      }
     }
-    
-    std::vector<uint8_t> data(content_str.begin(), content_str.end());
-    auto result = this->parent_->write_file(path_str, data);
-    
-    if (result != WriteResult::SUCCESS) {
-      ESP_LOGW("sd_spi_card.action", "Failed to write file: %s", path_str.c_str());
-    }
-  }
-
- protected:
+  
+protected:
   SdSpiCard *parent_;
 };
 
 template<typename... Ts>
 class SyncAction : public Action<Ts...> {
- public:
+public:
   explicit SyncAction(SdSpiCard *parent) : parent_(parent) {}
-
+  
   void play(Ts... x) override {
     this->parent_->sync();
   }
-
- protected:
+  
+protected:
   SdSpiCard *parent_;
 };
 
 template<typename... Ts>
 class CreateFileAction : public Action<Ts...> {
- public:
+public:
   explicit CreateFileAction(SdSpiCard *parent) : parent_(parent) {}
-
+  
   TEMPLATABLE_VALUE(std::string, path)
-  TEMPLATABLE_VALUE(std::string, content)
-
-  void play(Ts... x) override {
-    auto path_str = this->path_.value(x...);
-    auto content_str = this->content_.value(x...);
+    TEMPLATABLE_VALUE(std::string, content)
     
-    if (path_str.empty()) {
-      ESP_LOGW("sd_spi_card.action", "Path is empty, skipping file creation");
-      return;
+    void play(Ts... x) override {
+      auto path_str = this->path_.value(x...);
+      auto content_str = this->content_.value(x...);
+      
+      if (path_str.empty()) {
+        ESP_LOGW("sd_spi_card.action", "Path is empty, skipping file creation");
+        return;
+      }
+      
+      std::vector<uint8_t> data(content_str.begin(), content_str.end());
+      auto result = this->parent_->create_file(path_str, data);
+      
+      if (result != WriteResult::SUCCESS && result != WriteResult::NOT_MOUNTED) {
+        ESP_LOGW("sd_spi_card.action", "Failed to create file: %s", path_str.c_str());
+      }
     }
-    
-    std::vector<uint8_t> data(content_str.begin(), content_str.end());
-    auto result = this->parent_->create_file(path_str, data);
-    
-    if (result != WriteResult::SUCCESS && result != WriteResult::NOT_MOUNTED) {
-      ESP_LOGW("sd_spi_card.action", "Failed to create file: %s", path_str.c_str());
+  
+protected:
+  SdSpiCard *parent_;
+};
+
+template<typename... Ts>
+class MountAction : public Action<Ts...> {
+public:
+  explicit MountAction(SdSpiCard *parent) : parent_(parent) {}
+  
+  void play(Ts... x) override {
+    if (!this->parent_->mount()) {
+      ESP_LOGW("sd_spi_card.action", "Failed to mount SD card");
     }
   }
-
- protected:
+  
+protected:
   SdSpiCard *parent_;
 };
 

--- a/components/sd_spi_card/automation.h
+++ b/components/sd_spi_card/automation.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "sd_spi_card.h"
+
+namespace esphome {
+namespace sd_spi_card {
+
+// Trigger that fires when SD card is mounted
+class SdSpiCardMountTrigger : public Trigger<> {
+ public:
+  explicit SdSpiCardMountTrigger(SdSpiCard *parent) {
+    parent->add_on_mount_callback([this]() { this->trigger(); });
+  }
+};
+
+template<typename... Ts>
+class AppendFileAction : public Action<Ts...> {
+ public:
+  explicit AppendFileAction(SdSpiCard *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(std::string, path)
+  TEMPLATABLE_VALUE(std::string, content)
+
+  void play(Ts... x) override {
+    auto path_str = this->path_.value(x...);
+    auto content_str = this->content_.value(x...);
+    
+    if (path_str.empty()) {
+      ESP_LOGW("sd_spi_card.action", "Path is empty, skipping write");
+      return;
+    }
+    
+    std::vector<uint8_t> data(content_str.begin(), content_str.end());
+    auto result = this->parent_->append_file(path_str, data);
+    
+    if (result != WriteResult::SUCCESS) {
+      ESP_LOGW("sd_spi_card.action", "Failed to append to file: %s", path_str.c_str());
+    }
+  }
+
+ protected:
+  SdSpiCard *parent_;
+};
+
+template<typename... Ts>
+class WriteFileAction : public Action<Ts...> {
+ public:
+  explicit WriteFileAction(SdSpiCard *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(std::string, path)
+  TEMPLATABLE_VALUE(std::string, content)
+
+  void play(Ts... x) override {
+    auto path_str = this->path_.value(x...);
+    auto content_str = this->content_.value(x...);
+    
+    if (path_str.empty()) {
+      ESP_LOGW("sd_spi_card.action", "Path is empty, skipping write");
+      return;
+    }
+    
+    std::vector<uint8_t> data(content_str.begin(), content_str.end());
+    auto result = this->parent_->write_file(path_str, data);
+    
+    if (result != WriteResult::SUCCESS) {
+      ESP_LOGW("sd_spi_card.action", "Failed to write file: %s", path_str.c_str());
+    }
+  }
+
+ protected:
+  SdSpiCard *parent_;
+};
+
+template<typename... Ts>
+class SyncAction : public Action<Ts...> {
+ public:
+  explicit SyncAction(SdSpiCard *parent) : parent_(parent) {}
+
+  void play(Ts... x) override {
+    this->parent_->sync();
+  }
+
+ protected:
+  SdSpiCard *parent_;
+};
+
+template<typename... Ts>
+class CreateFileAction : public Action<Ts...> {
+ public:
+  explicit CreateFileAction(SdSpiCard *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(std::string, path)
+  TEMPLATABLE_VALUE(std::string, content)
+
+  void play(Ts... x) override {
+    auto path_str = this->path_.value(x...);
+    auto content_str = this->content_.value(x...);
+    
+    if (path_str.empty()) {
+      ESP_LOGW("sd_spi_card.action", "Path is empty, skipping file creation");
+      return;
+    }
+    
+    std::vector<uint8_t> data(content_str.begin(), content_str.end());
+    auto result = this->parent_->create_file(path_str, data);
+    
+    if (result != WriteResult::SUCCESS && result != WriteResult::NOT_MOUNTED) {
+      ESP_LOGW("sd_spi_card.action", "Failed to create file: %s", path_str.c_str());
+    }
+  }
+
+ protected:
+  SdSpiCard *parent_;
+};
+
+}  // namespace sd_spi_card
+}  // namespace esphome

--- a/components/sd_spi_card/sd_spi_card.cpp
+++ b/components/sd_spi_card/sd_spi_card.cpp
@@ -1,0 +1,388 @@
+#include "sd_spi_card.h"
+#include "esphome/core/log.h"
+#include <cstdio>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "ff.h"  // For FATFS type detection
+
+namespace esphome {
+namespace sd_spi_card {
+
+static const char *TAG = "sd_spi_card";
+
+void SdSpiCard::setup() {
+  ESP_LOGI(TAG, "Setting up SD card over SPI...");
+
+  if (clk_pin_ == GPIO_NUM_NC || mosi_pin_ == GPIO_NUM_NC ||
+      miso_pin_ == GPIO_NUM_NC || cs_pin_ == GPIO_NUM_NC) {
+    ESP_LOGE(TAG, "Pins not configured!");
+    this->mark_failed();
+    return;
+  }
+
+  if (!this->mount_card_()) {
+    ESP_LOGE(TAG, "Initial mount failed");
+    this->mark_failed();
+  }
+}
+
+bool SdSpiCard::mount_card_() {
+  if (mounted_) {
+    ESP_LOGW(TAG, "Card already mounted");
+    return true;
+  }
+
+  ESP_LOGI(TAG, "Mounting SD card...");
+
+  sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+  host.slot = spi_host_;
+
+  // Only initialize SPI bus once
+  if (!spi_initialized_) {
+    spi_bus_config_t bus_cfg = {};
+    bus_cfg.mosi_io_num = mosi_pin_;
+    bus_cfg.miso_io_num = miso_pin_;
+    bus_cfg.sclk_io_num = clk_pin_;
+    bus_cfg.quadwp_io_num = -1;
+    bus_cfg.quadhd_io_num = -1;
+    bus_cfg.max_transfer_sz = 4000;
+
+    esp_err_t ret = spi_bus_initialize((spi_host_device_t)host.slot, &bus_cfg, SDSPI_DEFAULT_DMA);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE(TAG, "Failed to initialize SPI bus: %s", esp_err_to_name(ret));
+      return false;
+    }
+    spi_initialized_ = true;
+  }
+
+  sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+  slot_config.gpio_cs = cs_pin_;
+  slot_config.host_id = (spi_host_device_t)host.slot;
+
+  esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+      .format_if_mount_failed = false,
+      .max_files = 5,
+      .allocation_unit_size = 16 * 1024};
+
+  esp_err_t ret = esp_vfs_fat_sdspi_mount(mount_point_.c_str(), &host, 
+                                          &slot_config, &mount_config, &card_);
+  if (ret != ESP_OK) {
+    if (ret == ESP_FAIL) {
+      ESP_LOGE(TAG, "Failed to mount filesystem.");
+      ESP_LOGE(TAG, "Card may not be formatted, or uses unsupported format.");
+      ESP_LOGE(TAG, "Supported formats: FAT16, FAT32");
+      ESP_LOGE(TAG, "NOT supported: exFAT, NTFS");
+      ESP_LOGE(TAG, "Please format the card as FAT32 (will erase all data)");
+    } else {
+      ESP_LOGE(TAG, "Failed to mount card: %s", esp_err_to_name(ret));
+    }
+    return false;
+  }
+
+  ESP_LOGI(TAG, "SD card mounted at %s", mount_point_.c_str());
+  mounted_ = true;
+  failed_writes_ = 0;
+
+  // Detect and log filesystem type
+  FATFS *fs;
+  DWORD free_clusters;
+  if (f_getfree("0:", &free_clusters, &fs) == FR_OK) {
+    const char *fs_type = "Unknown";
+    switch (fs->fs_type) {
+      case FS_FAT12: fs_type = "FAT12"; break;
+      case FS_FAT16: fs_type = "FAT16"; break;
+      case FS_FAT32: fs_type = "FAT32"; break;
+      case FS_EXFAT: fs_type = "exFAT (unsupported)"; break;
+    }
+    ESP_LOGI(TAG, "Filesystem type: %s", fs_type);
+    
+    if (fs->fs_type == FS_EXFAT) {
+      ESP_LOGW(TAG, "exFAT detected! This may cause issues.");
+      ESP_LOGW(TAG, "Consider reformatting as FAT32 for best compatibility.");
+    }
+  }
+  
+  // Trigger on_mount callbacks
+  this->mount_callback_.call();
+  
+  return true;
+}
+
+void SdSpiCard::unmount_card_() {
+  if (!mounted_) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "Unmounting SD card...");
+  esp_vfs_fat_sdcard_unmount(mount_point_.c_str(), card_);
+  mounted_ = false;
+  card_ = nullptr;
+}
+
+void SdSpiCard::loop() {
+  uint32_t now = millis();
+  
+  // Periodic card presence check
+  if (now - last_check_millis_ > check_interval_ms_) {
+    last_check_millis_ = now;
+    
+    if (!mounted_) {
+      // Try to remount if we're not mounted
+      ESP_LOGD(TAG, "Attempting to remount card...");
+      this->mount_card_();
+    } else {
+      // Verify card is still accessible
+      struct stat st;
+      if (stat(mount_point_.c_str(), &st) != 0) {
+        ESP_LOGW(TAG, "Card appears to be removed, unmounting...");
+        this->unmount_card_();
+      }
+    }
+  }
+
+  // If too many failed writes, try remounting
+  if (failed_writes_ >= MAX_FAILED_WRITES && mounted_) {
+    ESP_LOGW(TAG, "Too many failed writes, attempting remount...");
+    this->unmount_card_();
+    delay(100);
+    this->mount_card_();
+  }
+}
+
+bool SdSpiCard::check_and_remount() {
+  if (mounted_) {
+    return true;
+  }
+  return this->mount_card_();
+}
+
+void SdSpiCard::dump_config() {
+  ESP_LOGCONFIG(TAG, "SD SPI Card:");
+  ESP_LOGCONFIG(TAG, "  Mount Point: %s", mount_point_.c_str());
+  ESP_LOGCONFIG(TAG, "  Mounted: %s", mounted_ ? "YES" : "NO");
+  ESP_LOGCONFIG(TAG, "  CLK: GPIO%d", clk_pin_);
+  ESP_LOGCONFIG(TAG, "  MOSI: GPIO%d", mosi_pin_);
+  ESP_LOGCONFIG(TAG, "  MISO: GPIO%d", miso_pin_);
+  ESP_LOGCONFIG(TAG, "  CS: GPIO%d", cs_pin_);
+  if (this->is_failed()) {
+    ESP_LOGCONFIG(TAG, "  Status: FAILED");
+  }
+  
+  // Dump card info if mounted
+  if (mounted_) {
+    this->dump_info();
+  }
+}
+
+void SdSpiCard::dump_info() {
+  if (!mounted_ || !card_) {
+    ESP_LOGW(TAG, "No card mounted");
+    return;
+  }
+
+  ESP_LOGCONFIG(TAG, "SD Card Info:");
+  ESP_LOGCONFIG(TAG, "  Name: %s", card_->cid.name);
+
+  // Calculate actual capacity properly
+  uint64_t capacity_bytes = ((uint64_t)card_->csd.capacity) * card_->csd.sector_size;
+  uint64_t size_mb = capacity_bytes / (1024 * 1024);
+  uint64_t size_gb = capacity_bytes / (1024 * 1024 * 1024);
+
+  // Determine card type based on capacity
+  std::string type;
+  if (size_gb >= 32) {
+    type = "SDXC";
+  } else if (size_mb > 2048) {
+    type = "SDHC";
+  } else {
+    type = "SDSC";
+  }
+  ESP_LOGCONFIG(TAG, "  Type: %s", type.c_str());
+
+  // Speed in MHz
+  ESP_LOGCONFIG(TAG, "  Speed: %.2f MHz", (double)card_->csd.tr_speed / 1000000.0);
+
+  // Display size in appropriate units
+  if (size_gb > 0) {
+    ESP_LOGCONFIG(TAG, "  Size: %llu GB (%llu MB)", 
+                  (unsigned long long)size_gb, (unsigned long long)size_mb);
+  } else {
+    ESP_LOGCONFIG(TAG, "  Size: %llu MB", (unsigned long long)size_mb);
+  }
+
+  ESP_LOGCONFIG(TAG, "  Sector size: %d bytes", card_->csd.sector_size);
+  ESP_LOGCONFIG(TAG, "  Read block length: %d bytes", 1 << card_->csd.read_block_len);
+}
+
+WriteResult SdSpiCard::write_file(const std::string &path, 
+                                   const std::vector<uint8_t> &data) {
+  if (!mounted_) {
+    ESP_LOGE(TAG, "Card not mounted, cannot write file");
+    failed_writes_++;
+    return WriteResult::NOT_MOUNTED;
+  }
+
+  std::string full_path = mount_point_ + path;
+  FILE *f = fopen(full_path.c_str(), "w");
+  if (!f) {
+    ESP_LOGE(TAG, "Failed to open file for writing: %s", full_path.c_str());
+    failed_writes_++;
+    return WriteResult::FILE_ERROR;
+  }
+
+  size_t written = fwrite(data.data(), 1, data.size(), f);
+  
+  // Ensure data is flushed to card and check for errors
+  int flush_result = fflush(f);
+  int sync_result = fsync(fileno(f));
+  fclose(f);
+
+  if (written != data.size()) {
+    ESP_LOGE(TAG, "Write incomplete: %d/%d bytes to %s", 
+             (int)written, (int)data.size(), path.c_str());
+    failed_writes_++;
+    return WriteResult::WRITE_ERROR;
+  }
+  
+  if (flush_result != 0 || sync_result != 0) {
+    ESP_LOGE(TAG, "Failed to flush/sync data to %s (flush=%d, sync=%d)", 
+             path.c_str(), flush_result, sync_result);
+    failed_writes_++;
+    return WriteResult::WRITE_ERROR;
+  }
+
+  // Only log success after confirming write succeeded
+  ESP_LOGD(TAG, "Wrote %d bytes to %s", (int)data.size(), path.c_str());
+  std::string content(data.begin(), data.end());
+  ESP_LOGI(TAG, "Written to %s: %d bytes: %s", path.c_str(), (int)data.size(), content.c_str());
+  
+  failed_writes_ = 0;
+  return WriteResult::SUCCESS;
+}
+
+bool SdSpiCard::file_exists(const std::string &path) {
+  if (!mounted_) {
+    return false;
+  }
+  
+  std::string full_path = mount_point_ + path;
+  struct stat st;
+  return (stat(full_path.c_str(), &st) == 0);
+}
+
+WriteResult SdSpiCard::create_file(const std::string &path, 
+                                    const std::vector<uint8_t> &data) {
+  if (!mounted_) {
+    ESP_LOGE(TAG, "Card not mounted, cannot create file");
+    failed_writes_++;
+    return WriteResult::NOT_MOUNTED;
+  }
+
+  // Check if file already exists
+  if (file_exists(path)) {
+    ESP_LOGI(TAG, "File already exists, skipping creation: %s", path.c_str());
+    return WriteResult::SUCCESS;
+  }
+
+  // File doesn't exist, create it
+  std::string full_path = mount_point_ + path;
+  FILE *f = fopen(full_path.c_str(), "w");
+  if (!f) {
+    ESP_LOGE(TAG, "Failed to create file: %s", full_path.c_str());
+    failed_writes_++;
+    return WriteResult::FILE_ERROR;
+  }
+
+  size_t written = fwrite(data.data(), 1, data.size(), f);
+  
+  // Ensure data is flushed to card and check for errors
+  int flush_result = fflush(f);
+  int sync_result = fsync(fileno(f));
+  fclose(f);
+
+  if (written != data.size()) {
+    ESP_LOGE(TAG, "Write incomplete during file creation: %d/%d bytes to %s", 
+             (int)written, (int)data.size(), path.c_str());
+    failed_writes_++;
+    return WriteResult::WRITE_ERROR;
+  }
+  
+  if (flush_result != 0 || sync_result != 0) {
+    ESP_LOGE(TAG, "Failed to flush/sync data to %s (flush=%d, sync=%d)", 
+             path.c_str(), flush_result, sync_result);
+    failed_writes_++;
+    return WriteResult::WRITE_ERROR;
+  }
+
+  ESP_LOGI(TAG, "Created file %s: %d bytes", path.c_str(), (int)data.size());
+  
+  // Log content if not too large
+  if (data.size() > 0 && data.size() < 200) {
+    std::string content(data.begin(), data.end());
+    ESP_LOGI(TAG, "Initial content: %s", content.c_str());
+  }
+  
+  failed_writes_ = 0;
+  return WriteResult::SUCCESS;
+}
+
+WriteResult SdSpiCard::append_file(const std::string &path, 
+                                    const std::vector<uint8_t> &data) {
+  if (!mounted_) {
+    ESP_LOGE(TAG, "Card not mounted, cannot append file");
+    failed_writes_++;
+    return WriteResult::NOT_MOUNTED;
+  }
+
+  std::string full_path = mount_point_ + path;
+  FILE *f = fopen(full_path.c_str(), "a");
+  if (!f) {
+    ESP_LOGD(TAG, "File not found, creating new: %s", path.c_str());
+    f = fopen(full_path.c_str(), "w");
+  }
+  
+  if (!f) {
+    ESP_LOGE(TAG, "Failed to open file for appending: %s", path.c_str());
+    failed_writes_++;
+    return WriteResult::FILE_ERROR;
+  }
+
+  size_t written = fwrite(data.data(), 1, data.size(), f);
+  
+  // Ensure data is flushed to card and check for errors
+  int flush_result = fflush(f);
+  int sync_result = fsync(fileno(f));
+  fclose(f);
+
+  if (written != data.size()) {
+    ESP_LOGE(TAG, "Append incomplete: %d/%d bytes to %s", 
+             (int)written, (int)data.size(), path.c_str());
+    failed_writes_++;
+    return WriteResult::WRITE_ERROR;
+  }
+  
+  if (flush_result != 0 || sync_result != 0) {
+    ESP_LOGE(TAG, "Failed to flush/sync data to %s (flush=%d, sync=%d)", 
+             path.c_str(), flush_result, sync_result);
+    failed_writes_++;
+    return WriteResult::WRITE_ERROR;
+  }
+
+  // Only log success after confirming write succeeded
+  ESP_LOGD(TAG, "Appended %d bytes to %s", (int)data.size(), path.c_str());
+  std::string content(data.begin(), data.end());
+  ESP_LOGI(TAG, "Appended to %s: %d bytes: %s", path.c_str(), (int)data.size(), content.c_str());
+  
+  failed_writes_ = 0;
+  return WriteResult::SUCCESS;
+}
+
+void SdSpiCard::sync() {
+  if (mounted_) {
+    ::sync();  // Force all buffers to disk
+    ESP_LOGD(TAG, "Filesystem synced");
+  }
+}
+
+}  // namespace sd_spi_card
+}  // namespace esphome

--- a/components/sd_spi_card/sd_spi_card.cpp
+++ b/components/sd_spi_card/sd_spi_card.cpp
@@ -121,6 +121,9 @@ void SdSpiCard::unmount_card_() {
   esp_vfs_fat_sdcard_unmount(mount_point_.c_str(), card_);
   mounted_ = false;
   card_ = nullptr;
+  
+  // Set timer to try remounting sooner (30 seconds)
+  last_check_millis_ = millis() - check_interval_ms_ + remount_retry_interval_ms_;
 }
 
 void SdSpiCard::loop() {
@@ -391,7 +394,7 @@ WriteResult SdSpiCard::append_file(const std::string &path,
   // Only log success after confirming write succeeded
   ESP_LOGD(TAG, "Appended %d bytes to %s", (int)data.size(), path.c_str());
   std::string content(data.begin(), data.end());
-  ESP_LOGI(TAG, "Appended to %s: %d bytes: %s", path.c_str(), (int)data.size(), content.c_str());
+  ESP_LOGI(TAG, "Appended %d bytes to %s: %s", (int)data.size(), path.c_str(), content.c_str());
   
   failed_writes_ = 0;
   return WriteResult::SUCCESS;

--- a/components/sd_spi_card/sd_spi_card.cpp
+++ b/components/sd_spi_card/sd_spi_card.cpp
@@ -20,9 +20,13 @@ void SdSpiCard::setup() {
     return;
   }
   
-  if (!this->mount_card_()) {
-    ESP_LOGW(TAG, "Initial mount failed - will retry periodically");
-    // Don't mark as failed - allow loop() to retry mounting
+  if (auto_mount_) {
+    if (!this->mount_card_()) {
+      ESP_LOGW(TAG, "Initial mount failed - will retry periodically");
+      // Don't mark as failed - allow loop() to retry mounting
+    }
+  } else {
+    ESP_LOGI(TAG, "Auto-mount disabled - use mount action to mount card");
   }
 }
 
@@ -120,6 +124,11 @@ void SdSpiCard::unmount_card_() {
 }
 
 void SdSpiCard::loop() {
+  // Skip periodic checks if auto_mount is disabled
+  if (!auto_mount_) {
+    return;
+  }
+  
   uint32_t now = millis();
   
   // Periodic card presence check
@@ -156,9 +165,20 @@ bool SdSpiCard::check_and_remount() {
   return this->mount_card_();
 }
 
+bool SdSpiCard::mount() {
+  if (mounted_) {
+    ESP_LOGI(TAG, "Card already mounted");
+    return true;
+  }
+  
+  ESP_LOGI(TAG, "Manually mounting SD card...");
+  return this->mount_card_();
+}
+
 void SdSpiCard::dump_config() {
   ESP_LOGCONFIG(TAG, "SD SPI Card:");
   ESP_LOGCONFIG(TAG, "  Mount Point: %s", mount_point_.c_str());
+  ESP_LOGCONFIG(TAG, "  Auto Mount: %s", auto_mount_ ? "YES" : "NO");
   ESP_LOGCONFIG(TAG, "  Mounted: %s", mounted_ ? "YES" : "NO");
   ESP_LOGCONFIG(TAG, "  CLK: GPIO%d", clk_pin_);
   ESP_LOGCONFIG(TAG, "  MOSI: GPIO%d", mosi_pin_);

--- a/components/sd_spi_card/sd_spi_card.cpp
+++ b/components/sd_spi_card/sd_spi_card.cpp
@@ -12,17 +12,17 @@ static const char *TAG = "sd_spi_card";
 
 void SdSpiCard::setup() {
   ESP_LOGI(TAG, "Setting up SD card over SPI...");
-
+  
   if (clk_pin_ == GPIO_NUM_NC || mosi_pin_ == GPIO_NUM_NC ||
       miso_pin_ == GPIO_NUM_NC || cs_pin_ == GPIO_NUM_NC) {
     ESP_LOGE(TAG, "Pins not configured!");
     this->mark_failed();
     return;
   }
-
+  
   if (!this->mount_card_()) {
-    ESP_LOGE(TAG, "Initial mount failed");
-    this->mark_failed();
+    ESP_LOGW(TAG, "Initial mount failed - will retry periodically");
+    // Don't mark as failed - allow loop() to retry mounting
   }
 }
 
@@ -31,12 +31,12 @@ bool SdSpiCard::mount_card_() {
     ESP_LOGW(TAG, "Card already mounted");
     return true;
   }
-
+  
   ESP_LOGI(TAG, "Mounting SD card...");
-
+  
   sdmmc_host_t host = SDSPI_HOST_DEFAULT();
   host.slot = spi_host_;
-
+  
   // Only initialize SPI bus once
   if (!spi_initialized_) {
     spi_bus_config_t bus_cfg = {};
@@ -46,7 +46,7 @@ bool SdSpiCard::mount_card_() {
     bus_cfg.quadwp_io_num = -1;
     bus_cfg.quadhd_io_num = -1;
     bus_cfg.max_transfer_sz = 4000;
-
+    
     esp_err_t ret = spi_bus_initialize((spi_host_device_t)host.slot, &bus_cfg, SDSPI_DEFAULT_DMA);
     if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
       ESP_LOGE(TAG, "Failed to initialize SPI bus: %s", esp_err_to_name(ret));
@@ -54,16 +54,16 @@ bool SdSpiCard::mount_card_() {
     }
     spi_initialized_ = true;
   }
-
+  
   sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
   slot_config.gpio_cs = cs_pin_;
   slot_config.host_id = (spi_host_device_t)host.slot;
-
+  
   esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-      .format_if_mount_failed = false,
-      .max_files = 5,
-      .allocation_unit_size = 16 * 1024};
-
+    .format_if_mount_failed = false,
+    .max_files = 5,
+    .allocation_unit_size = 16 * 1024};
+  
   esp_err_t ret = esp_vfs_fat_sdspi_mount(mount_point_.c_str(), &host, 
                                           &slot_config, &mount_config, &card_);
   if (ret != ESP_OK) {
@@ -78,21 +78,21 @@ bool SdSpiCard::mount_card_() {
     }
     return false;
   }
-
+  
   ESP_LOGI(TAG, "SD card mounted at %s", mount_point_.c_str());
   mounted_ = true;
   failed_writes_ = 0;
-
+  
   // Detect and log filesystem type
   FATFS *fs;
   DWORD free_clusters;
   if (f_getfree("0:", &free_clusters, &fs) == FR_OK) {
     const char *fs_type = "Unknown";
     switch (fs->fs_type) {
-      case FS_FAT12: fs_type = "FAT12"; break;
-      case FS_FAT16: fs_type = "FAT16"; break;
-      case FS_FAT32: fs_type = "FAT32"; break;
-      case FS_EXFAT: fs_type = "exFAT (unsupported)"; break;
+    case FS_FAT12: fs_type = "FAT12"; break;
+    case FS_FAT16: fs_type = "FAT16"; break;
+    case FS_FAT32: fs_type = "FAT32"; break;
+    case FS_EXFAT: fs_type = "exFAT (unsupported)"; break;
     }
     ESP_LOGI(TAG, "Filesystem type: %s", fs_type);
     
@@ -112,7 +112,7 @@ void SdSpiCard::unmount_card_() {
   if (!mounted_) {
     return;
   }
-
+  
   ESP_LOGI(TAG, "Unmounting SD card...");
   esp_vfs_fat_sdcard_unmount(mount_point_.c_str(), card_);
   mounted_ = false;
@@ -139,7 +139,7 @@ void SdSpiCard::loop() {
       }
     }
   }
-
+  
   // If too many failed writes, try remounting
   if (failed_writes_ >= MAX_FAILED_WRITES && mounted_) {
     ESP_LOGW(TAG, "Too many failed writes, attempting remount...");
@@ -179,15 +179,15 @@ void SdSpiCard::dump_info() {
     ESP_LOGW(TAG, "No card mounted");
     return;
   }
-
+  
   ESP_LOGCONFIG(TAG, "SD Card Info:");
   ESP_LOGCONFIG(TAG, "  Name: %s", card_->cid.name);
-
+  
   // Calculate actual capacity properly
   uint64_t capacity_bytes = ((uint64_t)card_->csd.capacity) * card_->csd.sector_size;
   uint64_t size_mb = capacity_bytes / (1024 * 1024);
   uint64_t size_gb = capacity_bytes / (1024 * 1024 * 1024);
-
+  
   // Determine card type based on capacity
   std::string type;
   if (size_gb >= 32) {
@@ -198,10 +198,10 @@ void SdSpiCard::dump_info() {
     type = "SDSC";
   }
   ESP_LOGCONFIG(TAG, "  Type: %s", type.c_str());
-
+  
   // Speed in MHz
   ESP_LOGCONFIG(TAG, "  Speed: %.2f MHz", (double)card_->csd.tr_speed / 1000000.0);
-
+  
   // Display size in appropriate units
   if (size_gb > 0) {
     ESP_LOGCONFIG(TAG, "  Size: %llu GB (%llu MB)", 
@@ -209,19 +209,19 @@ void SdSpiCard::dump_info() {
   } else {
     ESP_LOGCONFIG(TAG, "  Size: %llu MB", (unsigned long long)size_mb);
   }
-
+  
   ESP_LOGCONFIG(TAG, "  Sector size: %d bytes", card_->csd.sector_size);
   ESP_LOGCONFIG(TAG, "  Read block length: %d bytes", 1 << card_->csd.read_block_len);
 }
 
 WriteResult SdSpiCard::write_file(const std::string &path, 
-                                   const std::vector<uint8_t> &data) {
+                                  const std::vector<uint8_t> &data) {
   if (!mounted_) {
     ESP_LOGE(TAG, "Card not mounted, cannot write file");
     failed_writes_++;
     return WriteResult::NOT_MOUNTED;
   }
-
+  
   std::string full_path = mount_point_ + path;
   FILE *f = fopen(full_path.c_str(), "w");
   if (!f) {
@@ -229,14 +229,14 @@ WriteResult SdSpiCard::write_file(const std::string &path,
     failed_writes_++;
     return WriteResult::FILE_ERROR;
   }
-
+  
   size_t written = fwrite(data.data(), 1, data.size(), f);
   
   // Ensure data is flushed to card and check for errors
   int flush_result = fflush(f);
   int sync_result = fsync(fileno(f));
   fclose(f);
-
+  
   if (written != data.size()) {
     ESP_LOGE(TAG, "Write incomplete: %d/%d bytes to %s", 
              (int)written, (int)data.size(), path.c_str());
@@ -250,7 +250,7 @@ WriteResult SdSpiCard::write_file(const std::string &path,
     failed_writes_++;
     return WriteResult::WRITE_ERROR;
   }
-
+  
   // Only log success after confirming write succeeded
   ESP_LOGD(TAG, "Wrote %d bytes to %s", (int)data.size(), path.c_str());
   std::string content(data.begin(), data.end());
@@ -271,19 +271,19 @@ bool SdSpiCard::file_exists(const std::string &path) {
 }
 
 WriteResult SdSpiCard::create_file(const std::string &path, 
-                                    const std::vector<uint8_t> &data) {
+                                   const std::vector<uint8_t> &data) {
   if (!mounted_) {
     ESP_LOGE(TAG, "Card not mounted, cannot create file");
     failed_writes_++;
     return WriteResult::NOT_MOUNTED;
   }
-
+  
   // Check if file already exists
   if (file_exists(path)) {
     ESP_LOGI(TAG, "File already exists, skipping creation: %s", path.c_str());
     return WriteResult::SUCCESS;
   }
-
+  
   // File doesn't exist, create it
   std::string full_path = mount_point_ + path;
   FILE *f = fopen(full_path.c_str(), "w");
@@ -292,14 +292,14 @@ WriteResult SdSpiCard::create_file(const std::string &path,
     failed_writes_++;
     return WriteResult::FILE_ERROR;
   }
-
+  
   size_t written = fwrite(data.data(), 1, data.size(), f);
   
   // Ensure data is flushed to card and check for errors
   int flush_result = fflush(f);
   int sync_result = fsync(fileno(f));
   fclose(f);
-
+  
   if (written != data.size()) {
     ESP_LOGE(TAG, "Write incomplete during file creation: %d/%d bytes to %s", 
              (int)written, (int)data.size(), path.c_str());
@@ -313,7 +313,7 @@ WriteResult SdSpiCard::create_file(const std::string &path,
     failed_writes_++;
     return WriteResult::WRITE_ERROR;
   }
-
+  
   ESP_LOGI(TAG, "Created file %s: %d bytes", path.c_str(), (int)data.size());
   
   // Log content if not too large
@@ -327,13 +327,13 @@ WriteResult SdSpiCard::create_file(const std::string &path,
 }
 
 WriteResult SdSpiCard::append_file(const std::string &path, 
-                                    const std::vector<uint8_t> &data) {
+                                   const std::vector<uint8_t> &data) {
   if (!mounted_) {
     ESP_LOGE(TAG, "Card not mounted, cannot append file");
     failed_writes_++;
     return WriteResult::NOT_MOUNTED;
   }
-
+  
   std::string full_path = mount_point_ + path;
   FILE *f = fopen(full_path.c_str(), "a");
   if (!f) {
@@ -346,14 +346,14 @@ WriteResult SdSpiCard::append_file(const std::string &path,
     failed_writes_++;
     return WriteResult::FILE_ERROR;
   }
-
+  
   size_t written = fwrite(data.data(), 1, data.size(), f);
   
   // Ensure data is flushed to card and check for errors
   int flush_result = fflush(f);
   int sync_result = fsync(fileno(f));
   fclose(f);
-
+  
   if (written != data.size()) {
     ESP_LOGE(TAG, "Append incomplete: %d/%d bytes to %s", 
              (int)written, (int)data.size(), path.c_str());
@@ -367,7 +367,7 @@ WriteResult SdSpiCard::append_file(const std::string &path,
     failed_writes_++;
     return WriteResult::WRITE_ERROR;
   }
-
+  
   // Only log success after confirming write succeeded
   ESP_LOGD(TAG, "Appended %d bytes to %s", (int)data.size(), path.c_str());
   std::string content(data.begin(), data.end());

--- a/components/sd_spi_card/sd_spi_card.h
+++ b/components/sd_spi_card/sd_spi_card.h
@@ -40,10 +40,15 @@ public:
   
   void set_mount_point(const std::string &path) { mount_point_ = path; }
   
+  void set_auto_mount(bool auto_mount) { auto_mount_ = auto_mount; }
+  
   // Register mount trigger
   void add_on_mount_callback(std::function<void()> &&callback) {
     this->mount_callback_.add(std::move(callback));
   }
+  
+  // Manually mount the card
+  bool mount();
   
   // Improved file helpers with error reporting
   WriteResult write_file(const std::string &path, const std::vector<uint8_t> &data);
@@ -62,6 +67,7 @@ protected:
   
 private:
   bool mounted_{false};
+  bool auto_mount_{true};
   std::string mount_point_{"/sd"};
   sdmmc_card_t *card_{nullptr};
   

--- a/components/sd_spi_card/sd_spi_card.h
+++ b/components/sd_spi_card/sd_spi_card.h
@@ -73,6 +73,7 @@ private:
   
   uint32_t last_check_millis_{0};
   uint32_t check_interval_ms_{300000};  // Check card every 5 minutes
+  uint32_t remount_retry_interval_ms_{30000};  // Retry remount every 30 seconds after ejection
   uint32_t failed_writes_{0};
   static constexpr uint32_t MAX_FAILED_WRITES = 3;
   

--- a/components/sd_spi_card/sd_spi_card.h
+++ b/components/sd_spi_card/sd_spi_card.h
@@ -19,32 +19,32 @@ enum class WriteResult {
 };
 
 class SdSpiCard : public Component {
- public:
+public:
   void setup() override;
   void dump_config() override;
   void loop() override;
   float get_setup_priority() const override { return setup_priority::IO; }
-
+  
   bool is_mounted() const { return mounted_; }
   void dump_info();
   
   // Check if card is still present and remount if needed
   bool check_and_remount();
-
+  
   void set_pins(int clk, int mosi, int miso, int cs) {
     clk_pin_ = (gpio_num_t)clk;
     mosi_pin_ = (gpio_num_t)mosi;
     miso_pin_ = (gpio_num_t)miso;
     cs_pin_   = (gpio_num_t)cs;
   }
-
+  
   void set_mount_point(const std::string &path) { mount_point_ = path; }
-
+  
   // Register mount trigger
   void add_on_mount_callback(std::function<void()> &&callback) {
     this->mount_callback_.add(std::move(callback));
   }
-
+  
   // Improved file helpers with error reporting
   WriteResult write_file(const std::string &path, const std::vector<uint8_t> &data);
   WriteResult append_file(const std::string &path, const std::vector<uint8_t> &data);
@@ -55,21 +55,21 @@ class SdSpiCard : public Component {
   
   // Ensure data is flushed to card
   void sync();
-
- protected:
+  
+protected:
   bool mount_card_();
   void unmount_card_();
-
- private:
+  
+private:
   bool mounted_{false};
   std::string mount_point_{"/sd"};
   sdmmc_card_t *card_{nullptr};
   
   uint32_t last_check_millis_{0};
-  uint32_t check_interval_ms_{10000};  // Check card every 10s
+  uint32_t check_interval_ms_{300000};  // Check card every 5 minutes
   uint32_t failed_writes_{0};
   static constexpr uint32_t MAX_FAILED_WRITES = 3;
-
+  
   gpio_num_t clk_pin_{GPIO_NUM_NC};
   gpio_num_t mosi_pin_{GPIO_NUM_NC};
   gpio_num_t miso_pin_{GPIO_NUM_NC};

--- a/components/sd_spi_card/sd_spi_card.h
+++ b/components/sd_spi_card/sd_spi_card.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/automation.h"
+#include "esp_vfs_fat.h"
+#include "sdmmc_cmd.h"
+
+namespace esphome {
+namespace sd_spi_card {
+
+class SdSpiCardMountTrigger;  // Forward declaration
+
+enum class WriteResult {
+  SUCCESS,
+  NOT_MOUNTED,
+  FILE_ERROR,
+  WRITE_ERROR
+};
+
+class SdSpiCard : public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+  float get_setup_priority() const override { return setup_priority::IO; }
+
+  bool is_mounted() const { return mounted_; }
+  void dump_info();
+  
+  // Check if card is still present and remount if needed
+  bool check_and_remount();
+
+  void set_pins(int clk, int mosi, int miso, int cs) {
+    clk_pin_ = (gpio_num_t)clk;
+    mosi_pin_ = (gpio_num_t)mosi;
+    miso_pin_ = (gpio_num_t)miso;
+    cs_pin_   = (gpio_num_t)cs;
+  }
+
+  void set_mount_point(const std::string &path) { mount_point_ = path; }
+
+  // Register mount trigger
+  void add_on_mount_callback(std::function<void()> &&callback) {
+    this->mount_callback_.add(std::move(callback));
+  }
+
+  // Improved file helpers with error reporting
+  WriteResult write_file(const std::string &path, const std::vector<uint8_t> &data);
+  WriteResult append_file(const std::string &path, const std::vector<uint8_t> &data);
+  WriteResult create_file(const std::string &path, const std::vector<uint8_t> &data);
+  
+  // Check if file exists
+  bool file_exists(const std::string &path);
+  
+  // Ensure data is flushed to card
+  void sync();
+
+ protected:
+  bool mount_card_();
+  void unmount_card_();
+
+ private:
+  bool mounted_{false};
+  std::string mount_point_{"/sd"};
+  sdmmc_card_t *card_{nullptr};
+  
+  uint32_t last_check_millis_{0};
+  uint32_t check_interval_ms_{10000};  // Check card every 10s
+  uint32_t failed_writes_{0};
+  static constexpr uint32_t MAX_FAILED_WRITES = 3;
+
+  gpio_num_t clk_pin_{GPIO_NUM_NC};
+  gpio_num_t mosi_pin_{GPIO_NUM_NC};
+  gpio_num_t miso_pin_{GPIO_NUM_NC};
+  gpio_num_t cs_pin_{GPIO_NUM_NC};
+  
+  spi_host_device_t spi_host_{HSPI_HOST};
+  bool spi_initialized_{false};
+  
+  CallbackManager<void()> mount_callback_;
+};
+
+}  // namespace sd_spi_card
+}  // namespace esphome

--- a/config/esp32.yaml
+++ b/config/esp32.yaml
@@ -10,6 +10,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    sdkconfig_options:
+      CONFIG_FATFS_LFN_STACK: "y"
 
 # Define ESPHome settings
 # https://esphome.io/components/esphome
@@ -21,7 +23,7 @@ esphome:
   min_version: "2025.9.0"
   project:
     name: "IEQLab.SAMBA"
-    version: "1.99.80"
+    version: "1.99.72"
   on_boot:
     - priority: 100
       then: 
@@ -40,9 +42,9 @@ esphome:
         
         # Print useful diagnostics
         - lambda: |-
-            ESP_LOGI("samba", "Startup OK :) Building: %s, Level: %s, Zone: %s, Influx: %s, Time: %s",
+            ESP_LOGI("samba", "Startup OK :) Building: %s, Level: %s, Zone: %s, Influx: %s, SD Card: %s, Time: %s",
                      id(building_tag).c_str(), id(level_tag).c_str(), id(zone_tag).c_str(),
-                     id(influx_enable) ? "true" : "false",
+                     id(influx_enable) ? "true" : "false", id(sd_enable) ? "true" : "false",
                      ESPTime::from_epoch_utc(id(ds1307_time).now().timestamp).strftime("%Y-%m-%dT%H:%M:%S+00:00").c_str());
 
             ESP_LOGI("samba", "Calibrations:\n"
@@ -79,6 +81,7 @@ logger:
     pmsx003: NONE
     senseair_i2c: ERROR
     sensirion_i2c: ERROR
+    sd_spi_card: INFO
     sgp4x: ERROR
     sound_level_meter: ERROR
     http_request: ERROR
@@ -92,7 +95,7 @@ i2c:
     sda: GPIO26
     scan: true
     frequency: 50kHz
-    timeout: 15ms
+    timeout: 20ms
 
 # Configure UART
 # https://esphome.io/components/uart

--- a/config/globals.yaml
+++ b/config/globals.yaml
@@ -29,6 +29,11 @@ globals:
     restore_value: yes
     initial_value: 'true'
 
+  - id: sd_enable
+    type: bool
+    restore_value: yes
+    initial_value: 'true'
+
   # CO2 calibration (y = mx + b)
   - id: calibration_co2_m
     type: double

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -87,6 +87,42 @@ script:
                       format: "Influx upload skipped"
                       level: INFO
                       tag: "samba"
+            - if:
+                condition: 
+                  - switch.is_on: switch_sdcard
+                then:
+                  - sd_spi_card.append_file:
+                      id: sd0
+                      path: "/samba.txt"
+                      content: !lambda |-
+                        auto t = id(ds1307_time).now();
+                        char ts[32];
+                        t.strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S");
+
+                        char buf[256];
+                        snprintf(buf, sizeof(buf),
+                          "%s,%.2f,%.2f,%.1f,%.3f,%.2f,%.0f,%.0f,%.1f,%.0f,%.0f,%.1f,%.1f,%.1f\n",
+                          ts,
+                          id(samba_temperature).state,
+                          id(samba_globe).state,
+                          id(samba_humidity).state,
+                          id(samba_airspeed).state,
+                          id(samba_mrt).state,
+                          id(samba_co2).state,
+                          id(samba_lux).state,
+                          id(samba_pm25).state,
+                          id(samba_tvoc).state,
+                          id(samba_nox).state,
+                          id(samba_laeq).state,
+                          id(samba_lamin).state,
+                          id(samba_lamax).state
+                        );
+                        return std::string(buf);
+                else:
+                  - logger.log:
+                      format: "SD card write skipped"
+                      level: INFO
+                      tag: "samba"
             - light.turn_off:
                 id: samba_led
                 transition_length: 300ms

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -77,7 +77,7 @@ script:
                 state: !lambda 'return id(samba_lamax).state;'
             - delay: 300ms
             - if:
-                condition: 
+                condition:
                   - switch.is_on: switch_influx
                 then:
                   - lambda: |-
@@ -88,8 +88,10 @@ script:
                       level: INFO
                       tag: "samba"
             - if:
-                condition: 
-                  - switch.is_on: switch_sdcard
+                condition:
+                  and:
+                    - switch.is_on: switch_sdcard
+                    - lambda: 'return id(sd0).is_mounted();'
                 then:
                   - sd_spi_card.append_file:
                       id: sd0

--- a/config/sd.yaml
+++ b/config/sd.yaml
@@ -43,6 +43,7 @@ button:
     name: "SD Card Mount"
     id: button_sdcard
     icon: mdi:sd
+    entity_category: "config"
     on_press:
       then:
         - sd_spi_card.mount:

--- a/config/sd.yaml
+++ b/config/sd.yaml
@@ -1,0 +1,38 @@
+# SAMBA v2 FIRMWARE
+# configure SD card
+# written by Thomas Parkinson, Oct 2025
+
+
+# define SD card
+sd_spi_card:
+  id: sd0
+  clk_pin: GPIO18
+  mosi_pin: GPIO23
+  miso_pin: GPIO19
+  cs_pin: GPIO5
+  
+  # Create file on succesful mount
+  on_mount:
+    - sd_spi_card.create_file:
+        id: sd0
+        path: "/samba.txt"
+        content: !lambda 'return "time,ta,tg,rh,as,mrt,co2,lux,pm25,tvoc,nox,laeq,lamin,lamax\n";'
+    - logger.log: 
+        level: INFO
+        format: "SD card mounted and initialized!"
+
+# Toggle SD write
+switch:
+  - platform: template
+    name: "SD Card Write"
+    id: switch_sdcard
+    icon: mdi:sd
+    entity_category: "config"
+    restore_mode: DISABLED
+    lambda: |-
+      return id(sd_enable);
+    turn_on_action:
+      - lambda: 'id(sd_enable) = true;'
+    turn_off_action:
+      - lambda: 'id(sd_enable) = false;'
+

--- a/config/sd.yaml
+++ b/config/sd.yaml
@@ -10,6 +10,7 @@ sd_spi_card:
   mosi_pin: GPIO23
   miso_pin: GPIO19
   cs_pin: GPIO5
+  auto_mount: true
   
   # Create file on succesful mount
   on_mount:
@@ -36,3 +37,14 @@ switch:
     turn_off_action:
       - lambda: 'id(sd_enable) = false;'
 
+# Manually mount SD card
+button:
+  - platform: template
+    name: "SD Card Mount"
+    id: button_sdcard
+    icon: mdi:sd
+    on_press:
+      then:
+        - sd_spi_card.mount:
+            id: sd0
+      

--- a/samba.yaml
+++ b/samba.yaml
@@ -22,6 +22,7 @@ packages:
   - !include config/tair.yaml
   - !include config/tglobe.yaml
   - !include config/airspeed.yaml
+  - !include config/sd.yaml
   - !include config/globals.yaml
   - !include config/substitutions.yaml
   - !include config/diagnostics.yaml

--- a/samba_setup.yaml
+++ b/samba_setup.yaml
@@ -29,6 +29,11 @@ globals:
     restore_value: yes
     initial_value: 'true'
 
+  - id: sd_enable
+    type: bool
+    restore_value: yes
+    initial_value: 'true'
+
   # CO2 Calibration (y = mx + b)
   - id: calibration_co2_m
     type: double
@@ -631,3 +636,17 @@ switch:
       - lambda: |-
           id(influx_enable) = false;
 
+  - platform: template
+    name: "Enable SD Card"
+    id: switch_sd
+    web_server:
+      sorting_group_id: sort_upload_settings
+    restore_mode: DISABLED
+    lambda: |-
+      return id(sd_enable);
+    turn_on_action:
+      - lambda: |-
+          id(sd_enable) = true;
+    turn_off_action:
+      - lambda: |-
+          id(sd_enable) = false;


### PR DESCRIPTION
This PR address issue #6 by adding support for writing SAMBA measurements to the onboard SD card using SPI. On boot, the card info is dumped if it is found. On successful mount, a file will be created (e.g. `samba.txt`) with a header. This file is then appended to every 5-minutes with the same data that is sent to InfluxDB. The log will print the data once written. Initial testing suggests it is working; more testing will be done to confirm.