### PR TITLE
Add publish_sensor action

### DIFF
--- a/components/influxdb/__init__.py
+++ b/components/influxdb/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import http_request, time
 from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
 from esphome import core
+from esphome import automation
 
 CODEOWNERS = ["@IEQLab"]
 DEPENDENCIES = ["http_request", "time"]
@@ -21,9 +22,11 @@ CONF_FIELD_NAME = "field_names"
 CONF_USE_SSL = "use_ssl"
 CONF_SENSORS_NAMES = "sensor_names"
 CONF_SEND_MAC = "send_mac"
+CONF_SENSOR_IDS = "sensor_ids"
 
 influxdb_ns = cg.esphome_ns.namespace("influxdb")
 InfluxDB = influxdb_ns.class_("InfluxDB", cg.Component)
+PublishSensorsAction = influxdb_ns.class_("PublishSensorsAction", automation.Action)
 
 def validate_update_interval(value):
     """Validate update interval using ESPHome's built-in validation that supports 'never'."""
@@ -123,3 +126,24 @@ async def to_code(config):
     if CONF_FIELD_NAME in config:
         for sensor_id, field_name in config[CONF_FIELD_NAME].items():
             cg.add(var.set_field_name(sensor_id, field_name))
+
+
+# Register action for selective sensor publishing
+@automation.register_action(
+    "influxdb.publish_sensors",
+    PublishSensorsAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(InfluxDB),
+            cv.Required(CONF_SENSOR_IDS): cv.ensure_list(cv.string),
+        }
+    ),
+)
+async def influxdb_publish_sensors_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    
+    for sensor_id in config[CONF_SENSOR_IDS]:
+        cg.add(var.add_sensor_id(sensor_id))
+    
+    return var

--- a/components/influxdb/influxdb.cpp
+++ b/components/influxdb/influxdb.cpp
@@ -331,15 +331,16 @@ void InfluxDB::publish_internal_(const std::unordered_set<std::string> *filter) 
   // Shrink buffer to actual size
   body.shrink_to_fit();
   
+  this->publish_in_progress_ = true;
+  
   if (filter != nullptr) {
     ESP_LOGI(TAG, "Publishing %zu filtered data points to InfluxDB", data_points);
   } else {
+    this->last_publish_ = millis();
     ESP_LOGI(TAG, "Publishing %zu data points to InfluxDB", data_points);
   }
   ESP_LOGVV(TAG, "Request body length: %u bytes", (unsigned) body.size());
   
-  this->publish_in_progress_ = true;
-  this->last_publish_ = millis();
   
   // One-shot IDF client (verify SSL if URL is https)
   const bool verify_ssl = this->url_.rfind("https://", 0) == 0;

--- a/components/influxdb/influxdb.cpp
+++ b/components/influxdb/influxdb.cpp
@@ -255,7 +255,21 @@ size_t InfluxDB::estimate_payload_size_() const {
   return std::max(estimated_size, MIN_BUFFER_SIZE);
 }
 
+// Add these method implementations to your influxdb.cpp
+// Replace your existing publish_now() method with these three methods
+
 void InfluxDB::publish_now() {
+  // Publish all configured sensors (no filter)
+  this->publish_internal_(nullptr);
+}
+
+void InfluxDB::publish_sensors(const std::vector<std::string> &sensor_ids) {
+  // Convert vector to unordered_set for O(1) lookup performance
+  std::unordered_set<std::string> filter(sensor_ids.begin(), sensor_ids.end());
+  this->publish_internal_(&filter);
+}
+
+void InfluxDB::publish_internal_(const std::unordered_set<std::string> *filter) {
   if (this->is_failed() || this->publish_in_progress_) {
     ESP_LOGW(TAG, "Cannot publish: component %s", 
              this->is_failed() ? "has failed" : "publish already in progress");
@@ -268,10 +282,16 @@ void InfluxDB::publish_now() {
   body.reserve(estimated_size);
   size_t data_points = 0;
   
-  // Build payload efficiently - no preflight checks
+  // Build payload efficiently - apply filter if provided
   for (auto *sensor : this->sensors_) {
     if (!std::isnan(sensor->state)) {
       const std::string &sensor_id = sensor->get_object_id();
+      
+      // Skip if filter is active and sensor not in filter
+      if (filter != nullptr && filter->find(sensor_id) == filter->end()) {
+        continue;
+      }
+      
       body += this->build_line_protocol_line_(sensor_id, to_string(sensor->state));
       data_points++;
     }
@@ -280,6 +300,12 @@ void InfluxDB::publish_now() {
   for (auto *text_sensor : this->text_sensors_) {
     if (!text_sensor->state.empty()) {
       const std::string &sensor_id = text_sensor->get_object_id();
+      
+      // Skip if filter is active and sensor not in filter
+      if (filter != nullptr && filter->find(sensor_id) == filter->end()) {
+        continue;
+      }
+      
       body += this->build_line_protocol_line_(sensor_id, text_sensor->state, true);
       data_points++;
     }
@@ -287,6 +313,11 @@ void InfluxDB::publish_now() {
   
 #ifdef USE_BINARY_SENSOR
   for (const auto &[sensor_id, state] : this->binary_sensor_states_) {
+    // Skip if filter is active and sensor not in filter
+    if (filter != nullptr && filter->find(sensor_id) == filter->end()) {
+      continue;
+    }
+    
     body += this->build_line_protocol_line_(sensor_id, std::to_string(state ? 1 : 0));
     data_points++;
   }
@@ -300,7 +331,11 @@ void InfluxDB::publish_now() {
   // Shrink buffer to actual size
   body.shrink_to_fit();
   
-  ESP_LOGI(TAG, "Publishing %zu data points to InfluxDB", data_points);
+  if (filter != nullptr) {
+    ESP_LOGI(TAG, "Publishing %zu filtered data points to InfluxDB", data_points);
+  } else {
+    ESP_LOGI(TAG, "Publishing %zu data points to InfluxDB", data_points);
+  }
   ESP_LOGVV(TAG, "Request body length: %u bytes", (unsigned) body.size());
   
   this->publish_in_progress_ = true;

--- a/components/influxdb/influxdb.h
+++ b/components/influxdb/influxdb.h
@@ -5,9 +5,11 @@
 #include <list>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <functional>
 
 #include "esphome/core/component.h"
+#include "esphome/core/automation.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/http_request/http_request.h"
@@ -20,28 +22,17 @@
 namespace esphome {
 namespace influxdb {
 
-/**
- * @brief InfluxDB Component
- * 
- * Collects sensor data from ESPHome and sends it to InfluxDB v2 via HTTP API.
- * Supports automatic sensor discovery, custom tags, field names, and timestamping.
- * Now supports templateable tag values using ESPHome globals.
- * 
- * @note This component uses ESP-IDF HTTP client directly for better memory management
- *       and SSL certificate validation. Each publish creates a one-shot HTTP connection
- *       that is cleaned up immediately to free TLS buffers.
- */
 class InfluxDB : public Component {
 public:
   // --- Constants ---
-  static constexpr uint32_t DEFAULT_UPDATE_INTERVAL_MS = 60000;  // 60 seconds
+  static constexpr uint32_t DEFAULT_UPDATE_INTERVAL_MS = 60000;
   static constexpr uint32_t UPDATE_INTERVAL_NEVER = UINT32_MAX;
   static constexpr int MAX_RETRY_ATTEMPTS = 2;
-  static constexpr size_t BASE_LINE_SIZE = 64;  // Estimated base size per line
+  static constexpr size_t BASE_LINE_SIZE = 64;
   static constexpr size_t MIN_BUFFER_SIZE = 256;
   static constexpr uint32_t BASE_BACKOFF_MS = 500;
   static constexpr uint32_t BACKOFF_RANGE_MS = 1500;
-  static constexpr int MAX_HTTP_RESPONSE_SIZE = 8192;  // 8KB limit for response drain
+  static constexpr int MAX_HTTP_RESPONSE_SIZE = 8192;
   
   // --- Component lifecycle ---
   void setup() override;
@@ -51,8 +42,9 @@ public:
   
   // --- Public API ---
   void publish_now();
+  void publish_sensors(const std::vector<std::string> &sensor_ids);
   
-  // --- Configuration setters (called by Python codegen) ---
+  // --- Configuration setters ---
   void set_host(const std::string &host) { host_ = host; }
   void set_port(const std::string &port) { port_ = port; }
   void set_token(const std::string &token) { token_ = token; }
@@ -75,23 +67,23 @@ public:
   void add_global_tag(const std::string &tag_key, const std::string &tag_value);
   void set_field_name(const std::string &sensor_id, const std::string &field_name);
   
-  // --- Template support for dynamic tags ---
+  // --- Template support ---
   void add_static_tag_template(const std::string &sensor_id, const std::string &tag_key, std::function<std::string()> func);
   void add_global_tag_template(const std::string &tag_key, std::function<std::string()> func);
   
 protected:
   // --- Configuration ---
-  std::string host_;  // InfluxDB host
+  std::string host_;
   std::string port_{"8086"};
-  std::string token_;  // InfluxDB token
-  std::string bucket_;  // InfluxDB bucket
-  std::string org_;  // InfluxDB org
+  std::string token_;
+  std::string bucket_;
+  std::string org_;
   std::string timestamp_unit_{"s"};
-  bool use_ssl_{false};  // Use HTTPS if true
-  bool send_mac_{false};  // Include MAC address tag
+  bool use_ssl_{false};
+  bool send_mac_{false};
   uint32_t update_interval_{DEFAULT_UPDATE_INTERVAL_MS};
   
-  // --- ESP-IDF HTTP client implementation ---
+  // --- HTTP client ---
   bool post_raw_idf_(const std::string &url,
                      const std::string &body,
                      const std::list<esphome::http_request::Header> &headers,
@@ -104,21 +96,17 @@ protected:
   uint32_t last_publish_{0};
   bool publish_in_progress_{false};
   
-  // --- Component dependencies ---
+  // --- Dependencies ---
   http_request::HttpRequestComponent *http_request_{nullptr};
   time::RealTimeClock *time_source_{nullptr};
   
   // --- Sensor management ---
-  std::unordered_map<std::string, std::string> sensor_measurements_;  // sensor_id -> measurement_name
-  std::unordered_map<std::string, std::string> field_names_;          // sensor_id -> field_name
-  
-  // --- Tag management (static strings) ---
-  std::unordered_map<std::string, std::unordered_map<std::string, std::string>> static_tags_;   // sensor_id -> {tag_key -> tag_value}
-  std::unordered_map<std::string, std::string> global_tags_;          // tag_key -> tag_value (applied to all measurements)
-  
-  // --- Template tag management (dynamic values) ---
-  std::unordered_map<std::string, std::unordered_map<std::string, std::function<std::string()>>> static_tag_templates_;  // sensor_id -> {tag_key -> template_func}
-  std::unordered_map<std::string, std::function<std::string()>> global_tag_templates_;  // tag_key -> template_func
+  std::unordered_map<std::string, std::string> sensor_measurements_;
+  std::unordered_map<std::string, std::string> field_names_;
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>> static_tags_;
+  std::unordered_map<std::string, std::string> global_tags_;
+  std::unordered_map<std::string, std::unordered_map<std::string, std::function<std::string()>>> static_tag_templates_;
+  std::unordered_map<std::string, std::function<std::string()>> global_tag_templates_;
   
   // --- Sensor collections ---
   std::vector<sensor::Sensor *> sensors_;
@@ -134,9 +122,12 @@ protected:
   void setup_headers_();
   size_t estimate_payload_size_() const;
   
+  // Modified to accept optional filter
+  void publish_internal_(const std::unordered_set<std::string> *filter = nullptr);
+  
   std::string build_line_protocol_line_(const std::string &sensor_id, const std::string &value, bool is_string_value = false);
   std::string build_measurement_name_(const std::string &sensor_id) const;
-  std::string build_tags_(const std::string &sensor_id) const;  // Modified to handle templates
+  std::string build_tags_(const std::string &sensor_id) const;
   std::string build_fields_(const std::string &sensor_id, const std::string &value, bool is_string_value = false) const;
   std::string build_timestamp_() const;
   
@@ -147,6 +138,25 @@ protected:
   std::string get_field_name_(const std::string &sensor_id) const;
   bool has_sensor_mapping_(const std::string &sensor_id) const;
   bool should_publish_() const;
+};
+
+// --- Action for selective publishing ---
+template<typename... Ts>
+class PublishSensorsAction : public Action<Ts...> {
+public:
+  explicit PublishSensorsAction(InfluxDB *parent) : parent_(parent) {}
+  
+  void add_sensor_id(const std::string &sensor_id) {
+    sensor_ids_.push_back(sensor_id);
+  }
+  
+  void play(Ts... x) override {
+    parent_->publish_sensors(sensor_ids_);
+  }
+  
+protected:
+  InfluxDB *parent_;
+  std::vector<std::string> sensor_ids_;
 };
 
 }  // namespace influxdb

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -80,8 +80,24 @@ script:
                 condition:
                   - switch.is_on: switch_influx
                 then:
-                  - lambda: |-
-                      id(influx).publish_now();
+                  - influxdb.publish_sensors:
+                      id: influx
+                      sensor_ids:
+                        - samba_temperature
+                        - samba_globe
+                        - samba_humidity
+                        - samba_airspeed
+                        - samba_mrt
+                        - samba_co2
+                        - samba_lux
+                        - samba_pm25
+                        - samba_tvoc
+                        - samba_nox
+                        - samba_laeq
+                        - samba_lamin
+                        - samba_lamax
+#                  - lambda: |-
+#                      id(influx).publish_now();
                 else:
                   - logger.log:
                       format: "Influx upload skipped"

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -83,21 +83,21 @@ script:
                   - influxdb.publish_sensors:
                       id: influx
                       sensor_ids:
-                        - samba_temperature
-                        - samba_globe
-                        - samba_humidity
-                        - samba_airspeed
-                        - samba_mrt
-                        - samba_co2
-                        - samba_lux
-                        - samba_pm25
-                        - samba_tvoc
-                        - samba_nox
-                        - samba_laeq
-                        - samba_lamin
-                        - samba_lamax
-#                  - lambda: |-
-#                      id(influx).publish_now();
+                        - air_temperature
+                        - globe_temperature
+                        - relative_humidity
+                        - air_speed
+                        - radiant_temperature
+                        - carbon_dioxide
+                        - illuminance
+                        - pm2_5
+                        - tvoc
+                        - nox_index
+                        - laeq
+                        - lamin
+                        - lamax
+                        - wifi_signal
+                        - device_uptime
                 else:
                   - logger.log:
                       format: "Influx upload skipped"


### PR DESCRIPTION
This PR implements the `influxdb.publish_sensor()` action for the InfluxBD external component. This sits alongside the existing `id(influx).publish_now()` but has the advantage of being able to accept a list of sensors to publish. This provides a lot of flexibility for setups to publish measurements at different frequencies to different InfluxDB instances.