### PR TITLE
Switch to LA90 and LA10

### DIFF
--- a/config/influx.yaml
+++ b/config/influx.yaml
@@ -32,8 +32,9 @@ influxdb:
     nox_index: "nox"
     illuminance: "illuminance"
     laeq: "la_eq"
-    lamin: "la_min"
-    lamax: "la_max"
+    la90: "la_90"
+    la10: "la_10"
+    la05: "la_05"
     wifi_signal: "wifi"
     device_uptime: "uptime"
 

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -100,7 +100,6 @@ script:
                         - laeq
                         - la90
                         - la10
-                        - la05
                         - wifi_signal
                         - device_uptime
                 else:
@@ -138,8 +137,7 @@ script:
                           id(samba_nox).state,
                           id(samba_laeq).state,
                           id(samba_la90).state,
-                          id(samba_la10).state,
-                          id(samba_la05).state
+                          id(samba_la10).state
                         );
                         return std::string(buf);
                 else:

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -33,8 +33,9 @@ script:
             - component.update: samba_tvoc
             - component.update: samba_nox
             - component.update: samba_laeq
-            - component.update: samba_lamin
-            - component.update: samba_lamax
+            - component.update: samba_la90
+            - component.update: samba_la10
+            - component.update: samba_la05
             - delay: 100ms
             - sensor.template.publish:
                 id: samba_temperature
@@ -70,11 +71,14 @@ script:
                 id: samba_laeq
                 state: !lambda 'return id(samba_laeq).state;'
             - sensor.template.publish:
-                id: samba_lamin
-                state: !lambda 'return id(samba_lamin).state;'
+                id: samba_la90
+                state: !lambda 'return id(samba_la90).state;'
             - sensor.template.publish:
-                id: samba_lamax
-                state: !lambda 'return id(samba_lamax).state;'
+                id: samba_la10
+                state: !lambda 'return id(samba_la10).state;'
+            - sensor.template.publish:
+                id: samba_la05
+                state: !lambda 'return id(samba_la05).state;'
             - delay: 300ms
             - if:
                 condition:
@@ -94,8 +98,9 @@ script:
                         - tvoc
                         - nox_index
                         - laeq
-                        - lamin
-                        - lamax
+                        - la90
+                        - la10
+                        - la05
                         - wifi_signal
                         - device_uptime
                 else:
@@ -132,8 +137,9 @@ script:
                           id(samba_tvoc).state,
                           id(samba_nox).state,
                           id(samba_laeq).state,
-                          id(samba_lamin).state,
-                          id(samba_lamax).state
+                          id(samba_la90).state,
+                          id(samba_la10).state,
+                          id(samba_la05).state
                         );
                         return std::string(buf);
                 else:

--- a/config/sd.yaml
+++ b/config/sd.yaml
@@ -35,7 +35,7 @@ script:
           content: !lambda |- 
             char header[256];
             snprintf(header, sizeof(header),
-                     "# version: %s\n# building: %s\n# level: %s\n# zone: %s\ntime,ta,tg,rh,as,mrt,co2,lux,pm25,tvoc,nox,laeq,lamin,lamax\n",
+                     "# version: %s\n# building: %s\n# level: %s\n# zone: %s\ntime,ta,tg,rh,as,mrt,co2,lux,pm25,tvoc,nox,laeq,la90,la10,la05\n",
                      ESPHOME_VERSION,
                      id(building_tag).c_str(),
                      id(level_tag).c_str(),

--- a/config/spl.yaml
+++ b/config/spl.yaml
@@ -29,7 +29,7 @@ sound_level_meter:
     microphone: samba_mic
     bits_per_sample: 32
   auto_start: true
-  ring_buffer_size: 100ms
+  ring_buffer_size: 125ms
   warmup_interval: 500ms
 
   # audio processing task
@@ -74,48 +74,59 @@ sound_level_meter:
   # calculate LAeq (average) sound level over specified period
   sensors:
     - type: eq
-      id: spl_laeq
+      id: spl_laeq_raw
       update_interval: 500ms
       internal: true
       dsp_filters: [f_ics43434, f_a]
       filters:
         - filter_out: nan
-        - median:
-            window_size: 600
-            send_every: 60
-            send_first_at: 30
 
-  # calculate Lmin over specified period
-    - type: min
-      id: spl_lamin
-      window_size: 1s
-      update_interval: 60s
-      internal: true
-      dsp_filters: [f_ics43434, f_a]
-      filters:
-        - filter_out: nan
-        - min:
-            window_size: 5
-            send_every: 1
-            send_first_at: 1
-
-  # calculate Lmax over specified period
-    - type: max
-      id: spl_lamax
-      window_size: 1s
-      update_interval: 60s
-      internal: true
-      dsp_filters: [f_ics43434, f_a]
-      filters:
-        - filter_out: nan
-        - max:
-            window_size: 5
-            send_every: 1
-            send_first_at: 1
-
-
-# Define SPL measurement
+# Derive percentiles from LAeq measurements
 sensor:
+  - platform: copy
+    source_id: spl_laeq_raw
+    id: spl_laeq
+    internal: true
+    filters:
+      - median:
+          window_size: 600
+          send_every: 120
+          send_first_at: 60
+
+  - platform: copy
+    source_id: spl_laeq_raw
+    id: spl_la90
+    internal: true
+    filters:
+      - quantile:
+          window_size: 600
+          quantile: 0.10
+          send_every: 120
+          send_first_at: 60
+
+  - platform: copy
+    source_id: spl_laeq_raw
+    id: spl_la10
+    internal: true
+    filters:
+      - quantile:
+          window_size: 600
+          quantile: 0.90
+          send_every: 120
+          send_first_at: 60
+
+  - platform: copy
+    source_id: spl_laeq_raw
+    id: spl_la05
+    internal: true
+    filters:
+      - quantile:
+          window_size: 600
+          quantile: 0.95
+          send_every: 120
+          send_first_at: 60
+
+# Define SPL measurements
   - platform: template
     id: samba_laeq
     name: "LAeq"
@@ -128,23 +139,34 @@ sensor:
       return id(spl_laeq).state;
 
   - platform: template
-    id: samba_lamin
-    name: "LAmin"
+    id: samba_la90
+    name: "LA90"
     update_interval: never
     accuracy_decimals: 1
     device_class: sound_pressure
     unit_of_measurement: "dBA"
     icon: mdi:volume-low
     lambda: |-
-      return id(spl_lamin).state;
+      return id(spl_la90).state;
 
   - platform: template
-    id: samba_lamax
-    name: "LAmax"
+    id: samba_la10
+    name: "LA10"
     update_interval: never
     accuracy_decimals: 1
     device_class: sound_pressure
     unit_of_measurement: "dBA"
     icon: mdi:volume-high
     lambda: |-
-      return id(spl_lamax).state;
+      return id(spl_la10).state;
+
+  - platform: template
+    id: samba_la05
+    name: "LA05"
+    update_interval: never
+    accuracy_decimals: 1
+    device_class: sound_pressure
+    unit_of_measurement: "dBA"
+    icon: mdi:volume-high
+    lambda: |-
+      return id(spl_la05).state;


### PR DESCRIPTION
This PR replaces LAmin and LAmax with LA90 and LA10, respectively. These are more useful metrics for assessing acoustic environments. This involved a slight change to the way LAeq is sampled; it now uses a copy of the raw LAeq sensor and then applies the media window. The LAmin and LAmax sensors are also copies of the raw sensor and apply a quantile filter to determine the values. LA05 is also calculated but is not published to InfluxDB or the SD card.